### PR TITLE
Increase stack; fix signal timings; use new interrupt API; other cleanups

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -23,7 +23,7 @@ void rainbow(void *pvParameters)
 {
   const uint8_t anim_step = 10;
   const uint8_t anim_max = 250;
-  const uint8_t pixel_count = 9; // Number of your "pixels"
+  const uint8_t pixel_count = 64; // Number of your "pixels"
   const uint8_t delay = 25; // duration between color changes
   rgbVal color = makeRGBVal(anim_max, 0, 0);
   uint8_t step = 0;
@@ -91,7 +91,7 @@ void app_main()
   nvs_flash_init();
 
   ws2812_init(WS2812_PIN);
-  xTaskCreate(rainbow, "ws2812 rainbow demo", 256, NULL, 10, NULL);
+  xTaskCreate(rainbow, "ws2812 rainbow demo", 4096, NULL, 10, NULL);
 
   return;
 }


### PR DESCRIPTION
Now that I understand how this all works, I ported a few updates from my main work on this (https://github.com/MartyMacGyver/ESP32-digital-RGB-LED-drivers) to your original code.

Increased stack size (2048 might work but I used 4096 to be safe, esp. with larger panels)
Fixed WS2812/WS2812B signal timings
Used new interrupt API
Demonstrates use of DURATION
Set a slightly larger default panel size

Closes #3 and #4 